### PR TITLE
Rename on(), off() functions to watch(), ignore()

### DIFF
--- a/src/sentinel.js
+++ b/src/sentinel.js
@@ -160,7 +160,7 @@ function animationStartHandler(ev) {
 
 // return singleton object
 return {
-  on: onFn,
-  off: offFn,
+  watch: onFn,
+  ignore: offFn,
   reset: resetFn
 };


### PR DESCRIPTION
I've only renamed the fields on the returned singleton for now to keep things simple, but I think `on()` and `off()` functions don't make sense without an attributed action. Typically you'd get `on('click',...)` for example.

This just makes things clear that you're setting up a watcher/listener on the CSS selector.